### PR TITLE
Use idiomatic OPENAI_API_KEY environment variable over OPENAI_KEY, which is rarely used.

### DIFF
--- a/agents/examples/chat.rs
+++ b/agents/examples/chat.rs
@@ -16,7 +16,7 @@ impl Person {
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let model = GPT4::new(dotenv::var("OPENAI_KEY").unwrap());
+    let model = GPT4::new(dotenv::var("OPENAI_API_KEY").unwrap());
 
     let mut joseph = Person::new(&model, "Joseph");
     let mut maria = Person::new(&model, "Maria");

--- a/agents/examples/function.rs
+++ b/agents/examples/function.rs
@@ -27,7 +27,7 @@ fn instruction_quote_amount(arguments: String) -> String {
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let api_key = dotenv::var("OPENAI_KEY").expect("Environment variable OPENAI_KEY is not set.");
+    let api_key = dotenv::var("OPENAI_API_KEY").expect("Environment variable OPENAI_KEY is not set.");
     let model = GPT4::new(api_key);
 
     let mut dealer = Agent::new(&model, "Currency Exchange Dealer")


### PR DESCRIPTION
The code examples will likely not run on many people's systems without this change, as the name is typically `OPENAI_API_KEY`.

It's also potentially worth implementing the option to provide an API key during runtime if one isn't found at `OPENAI_API_KEY`; I will go ahead and work on that (on my fork) and potentially colorizing the output of the chats, but I'll wait on your input as to whether I should use standard ANSI colour codes (eg. `"\x1b[0m"`) or use a crate like [colored](https://crates.io/crates/colored), which would be more readable but add another dependency for a rather frivolous reason.