### PR TITLE
Function call should be a self-talk

### DIFF
--- a/agents/src/agent/mod.rs
+++ b/agents/src/agent/mod.rs
@@ -38,8 +38,13 @@ impl Agent {
 
     async fn talk_to_in(&mut self, recipient: &mut Self, conversation: &mut Conversation) {
         let mut message = self.model.complete(&self.instruction, conversation).await;
-        message.sign(self, recipient);
-        conversation.add_message(message);
+        if message.content.is_function_call() {
+            message.sign(self, self);
+            conversation.add_message(message);
+        } else {
+            message.sign(self, recipient);
+            conversation.add_message(message);
+        }
 
         if let Some(notifications) = &self.notifications {
             notifications(conversation);
@@ -52,8 +57,7 @@ impl Agent {
                 conversation.add_message(message);
                 recipient.pass_turn_to(self, conversation).await;
             }
-        }
-        if !conversation.has_terminated() {
+        } else if !conversation.has_terminated() {
             self.pass_turn_to(recipient, conversation).await
         }
     }


### PR DESCRIPTION
I am fixing an issue where the agent was replying the function call parameters back instead of only replying the function call output.

It's fixed as a self-talk.
But I also considered adding a 3rd agent to serve as the FunctionExecutor. This needs more thought.